### PR TITLE
Added an auto-update plugin registry

### DIFF
--- a/update-info/protege-5/update.properties
+++ b/update-info/protege-5/update.properties
@@ -1,0 +1,7 @@
+name=SHACL4P Constraint Validator
+id=shacl4p
+version=0.4.0
+download=https://github.com/fekaputra/shacl-plugin/releases/download/v0.4.0/at.ac.tuwien.shacl.plugin-0.4.0.jar
+readme=https://raw.githubusercontent.com/fekaputra/shacl-plugin/master/update-info/protege-5/readme.html
+license=https://raw.githubusercontent.com/fekaputra/shacl-plugin/master/LICENSE
+author=Fajar Ekaputra, Xiashuo Lin


### PR DESCRIPTION
Hi Fajar,

I've added an auto-update registry in your project to let Protege automatically check your plugin. So when users go to "File > Check for plugins...", they can install the plugin automatically.

A few notes though:
1. Feel free to edit the values in `update-info/protege-5/update.properties` accordingly. The ones that I've made are just an example.
2. Please create a `readme.html` file to describe your plugin. An example: https://raw.githubusercontent.com/protegeproject/cellfie-plugin/master/src/main/resources/readme.html
3. (Optional) I would recommend changing the plugin version to 1.0.0, so people will know the plugin is a production-ready product. Version 0.x usually means a beta version.

Once the `update.properties` is ready, please let me know and I will include your `update.properties` registry in the Protege code base. We would like to promote your plugin to the community basically (:

Let me know if you have any questions!

Best,
Josef